### PR TITLE
OpenTcpSocketAsync/GetHostAddressesAsync: use new cancellation token overloads

### DIFF
--- a/src/SingleStoreConnector/Core/ServerSession.cs
+++ b/src/SingleStoreConnector/Core/ServerSession.cs
@@ -1035,7 +1035,11 @@ internal sealed class ServerSession
 						{
 							if (ioBehavior == IOBehavior.Asynchronous)
 							{
+#if NET5_0_OR_GREATER
+								await tcpClient.ConnectAsync(ipAddress, cs.Port, cancellationToken).ConfigureAwait(false);
+#else
 								await tcpClient.ConnectAsync(ipAddress, cs.Port).ConfigureAwait(false);
+#endif
 							}
 							else
 							{
@@ -1056,7 +1060,7 @@ internal sealed class ServerSession
 								}
 							}
 						}
-						catch (ObjectDisposedException) when (cancellationToken.IsCancellationRequested)
+						catch (Exception ex) when ((ex is ObjectDisposedException || ex is OperationCanceledException) && cancellationToken.IsCancellationRequested)
 						{
 							SafeDispose(ref tcpClient);
 							Log.Info("Session{0} connect timeout expired connecting to IpAddress {1} for HostName '{2}'", m_logArguments[0], ipAddress, hostName);

--- a/src/SingleStoreConnector/Core/ServerSession.cs
+++ b/src/SingleStoreConnector/Core/ServerSession.cs
@@ -1060,7 +1060,7 @@ internal sealed class ServerSession
 								}
 							}
 						}
-						catch (Exception ex) when ((ex is ObjectDisposedException || ex is OperationCanceledException) && cancellationToken.IsCancellationRequested)
+						catch (ObjectDisposedException) when (cancellationToken.IsCancellationRequested)
 						{
 							SafeDispose(ref tcpClient);
 							Log.Info("Session{0} connect timeout expired connecting to IpAddress {1} for HostName '{2}'", m_logArguments[0], ipAddress, hostName);

--- a/src/SingleStoreConnector/Core/ServerSession.cs
+++ b/src/SingleStoreConnector/Core/ServerSession.cs
@@ -1011,7 +1011,11 @@ internal sealed class ServerSession
 			try
 			{
 				ipAddresses = ioBehavior == IOBehavior.Asynchronous
+#if NET6_0_OR_GREATER
+					? await Dns.GetHostAddressesAsync(hostName, cancellationToken).ConfigureAwait(false)
+#else
 					? await Dns.GetHostAddressesAsync(hostName).ConfigureAwait(false)
+#endif
 					: Dns.GetHostAddresses(hostName);
 			}
 			catch (SocketException)


### PR DESCRIPTION
There is a cancellable variant introduced in .Net 5.0:
https://learn.microsoft.com/en-us/dotnet/api/system.net.sockets.tcpclient.connectasync?view=net-5.0#system-net-sockets-tcpclient-connectasync(system-string-system-int32-system-threading-cancellationtoken)

We are observing issue where the cancellation doesn't take effect properly. In particular suspecting this could be the issue described here https://github.com/dotnet/runtime/issues/17611
