### PR TITLE
Lock-free session state checks on ServerSession#VerifyConnected

### DIFF
--- a/src/SingleStoreConnector/Core/ServerSession.cs
+++ b/src/SingleStoreConnector/Core/ServerSession.cs
@@ -984,13 +984,11 @@ internal sealed class ServerSession
 
 	private void VerifyConnected()
 	{
-		lock (m_lock)
-		{
-			if (m_state == State.Closed)
-				throw new ObjectDisposedException(nameof(ServerSession));
-			if (m_state != State.Connected && m_state != State.Querying && m_state != State.CancelingQuery && m_state != State.Closing)
-				throw new InvalidOperationException("ServerSession is not connected.");
-		}
+		State state = m_state;
+		if (state == State.Closed)
+			throw new ObjectDisposedException(nameof(ServerSession));
+		if (state != State.Connected && state != State.Querying && state != State.CancelingQuery && state != State.Closing)
+			throw new InvalidOperationException("ServerSession is not connected.");
 	}
 
 	private async Task<bool> OpenTcpSocketAsync(ConnectionSettings cs, ILoadBalancer loadBalancer, Activity? activity, IOBehavior ioBehavior, CancellationToken cancellationToken)
@@ -1987,7 +1985,7 @@ internal sealed class ServerSession
 	private readonly object?[] m_logArguments;
 	private readonly ArraySegmentHolder<byte> m_payloadCache;
 	private readonly ActivityTagsCollection m_activityTags;
-	private State m_state;
+	private volatile State m_state;
 	private TcpClient? m_tcpClient;
 	private Socket? m_socket;
 	private Stream? m_stream;


### PR DESCRIPTION
When iterating of rows, some of our benchmarks seem to indicate a massive hotspot on the `VerifyConnected` method, which gets called on each row iterated. More context on related issue on upstream MysqlConnector repo: https://github.com/mysql-net/MySqlConnector/issues/1153#issuecomment-2501372751

The fix proposed in this PR is to replace the lock by a volatile on attribute `ServerSession#m_state`, this loosens up the concurrency primitives used, and dramatically increased the client-side throughput on our benchmarks.  If I'm not mistaken, functionally speaking this should still cover a similar contract as the lock-based implementation.

We'll try to confirm the impact of this change on our production infrastructure.

Note that this change may cause backwards compatibility problems in terms of DB load spikes. For example, in our benchmarks, because of the 4-6x increased throughput on the C# client, the DB's CPU load also increased substantially.