### PR TITLE
Pack nuget in Release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -135,7 +135,7 @@ jobs:
       - run:
           name: Build NuGet package
           command: |
-            dotnet pack --output /net_connector -p:PackageVersion=<< pipeline.parameters.connector-version >>
+            dotnet pack -c Release --output /net_connector -p:PackageVersion=<< pipeline.parameters.connector-version >>
       - store_artifacts:
           path: /net_connector
 


### PR DESCRIPTION
The assembly is still published in Debug despite https://github.com/memsql/SingleStoreNETConnector/pull/7

![image](https://github.com/user-attachments/assets/1cdafcbc-ed80-4d2f-9aa3-c6d495e71ad8)
