### PR TITLE
Switch Github Actions from CIAB to dev image

### DIFF
--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -11,16 +11,50 @@ env:
   S2MS_API_KEY: ${{ secrets.S2MS_API_KEY }}
 
 jobs:
+  fetch-s2-versions:
+    name: Fetch SingleStore supported versions
+    runs-on: ubuntu-latest
+    outputs:
+      versions: ${{ steps.get_versions.outputs.versions }}
+    steps:
+      - name: Get supported versions of SingleStore
+        id: get_versions
+        uses: singlestore-labs/singlestore-supported-versions@main
+        with:
+          include_rc: true
+
+  build-matrix:
+    name: Build test matrix
+    runs-on: ubuntu-latest
+    needs: fetch-s2-versions
+    outputs:
+      matrix: ${{ steps.compose.outputs.matrix }}
+    steps:
+      - name: Install jq
+        run: sudo apt-get update && sudo apt-get install -y jq
+
+      - name: Compose matrix JSON
+        id: compose
+        env:
+          VERSIONS: ${{ needs.fetch-s2-versions.outputs.versions }}
+        run: |
+          rows=$(jq -cn --argjson versions "$VERSIONS" '
+            $versions | map({
+              name: ("SingleStore " + . + " tests"),
+              singlestore_version: (.)
+            })
+          ')
+
+          matrix=$(jq -cn --argjson rows "$rows" '{ include: $rows }')
+
+          echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
+
   test-ubuntu:
+    name: ${{ matrix.name }}
     runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
-      matrix:
-        singlestore_image:
-          - singlestore/cluster-in-a-box:alma-8.7.12-483e5f8acb-4.1.0-1.17.15
-          - singlestore/cluster-in-a-box:alma-8.5.22-fe61f40cd1-4.1.0-1.17.11
-    env:
-      SINGLESTORE_IMAGE: ${{ matrix.singlestore_image }}
+      matrix: ${{ fromJson(needs.build-matrix.outputs.matrix) }}
     steps:
       - uses: actions/checkout@v4
 
@@ -58,6 +92,8 @@ jobs:
 
       - name: Start SingleStore Cluster
         run: ./.github/workflows/setup_cluster.sh
+        env:
+          SINGLESTORE_VERSION: ${{ matrix.singlestore_version }}
 
       - name: Build connector
         run: dotnet build -c Release

--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -52,6 +52,7 @@ jobs:
   test-ubuntu:
     name: ${{ matrix.name }}
     runs-on: ubuntu-22.04
+    needs: build-matrix
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.build-matrix.outputs.matrix) }}
@@ -136,7 +137,6 @@ jobs:
           cd tests/SideBySide
           dotnet test -f ${{ env.TARGET_FRAMEWORK }} -c Release --no-build
           cd ../../
-
 
   test-windows:
     runs-on: windows-latest

--- a/.github/workflows/setup_cluster.sh
+++ b/.github/workflows/setup_cluster.sh
@@ -22,6 +22,7 @@ fi
 if [[ "${EXISTS}" -eq 0 ]]; then
     docker run -d \
         --name ${CONTAINER_NAME} \
+        -v ${PWD}/.ci/server/certs:/test-ssl \
         -e SINGLESTORE_LICENSE=${LICENSE_KEY} \
         -e ROOT_PASSWORD=${SQL_USER_PASSWORD} \
         -e SINGLESTORE_VERSION=${VERSION} \

--- a/.github/workflows/setup_cluster.sh
+++ b/.github/workflows/setup_cluster.sh
@@ -1,8 +1,11 @@
 #!/usr/bin/env bash
 set -eu
 
-DEFAULT_IMAGE_NAME="memsql/cluster-in-a-box:centos-7.3.9-a7abc2ebd4-3.2.8-1.11.4"
-IMAGE_NAME="${SINGLESTORE_IMAGE:-$DEFAULT_IMAGE_NAME}"
+IMAGE_NAME="ghcr.io/singlestore-labs/singlestoredb-dev:latest"
+
+DEFAULT_SINGLESTORE_VERSION="8.9"
+VERSION="${SINGLESTORE_VERSION:-$DEFAULT_SINGLESTORE_VERSION}"
+
 CONTAINER_NAME="singlestore-integration"
 
 EXISTS=$(docker inspect ${CONTAINER_NAME} >/dev/null 2>&1 && echo 1 || echo 0)
@@ -17,11 +20,11 @@ if [[ "${EXISTS}" -eq 1 ]]; then
 fi
 
 if [[ "${EXISTS}" -eq 0 ]]; then
-    docker run -i --init \
+    docker run -d \
         --name ${CONTAINER_NAME} \
-        -v ${PWD}/.ci/server/certs:/test-ssl \
-        -e LICENSE_KEY=${LICENSE_KEY} \
+        -e SINGLESTORE_LICENSE=${LICENSE_KEY} \
         -e ROOT_PASSWORD=${SQL_USER_PASSWORD} \
+        -e SINGLESTORE_VERSION=${VERSION} \
         -p 3306:3306 -p 3307:3307 \
         ${IMAGE_NAME}
 fi


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> CI-only changes, but they alter the Docker image, version selection, and license env vars used to provision SingleStore, which can significantly impact test reliability and coverage.
> 
> **Overview**
> Ubuntu CI now builds its test matrix from the current set of *supported SingleStore versions* (including RCs) fetched at workflow runtime, replacing the previously hardcoded `cluster-in-a-box` image list.
> 
> The cluster setup script switches to `ghcr.io/singlestore-labs/singlestoredb-dev:latest`, passes `SINGLESTORE_VERSION` into the container, and updates licensing env wiring (`LICENSE_KEY` -> `SINGLESTORE_LICENSE`), so each matrix run provisions the requested server version before running the existing test suites.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b72bd23ddc7b2fbf1ac3206c182b06ccc9045396. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->