### PR TITLE
Add Cloud Agent development environment

### DIFF
--- a/.cursor/Dockerfile
+++ b/.cursor/Dockerfile
@@ -1,0 +1,22 @@
+# Development environment for the SingleStore .NET Connector.
+#
+# The .NET 10 SDK is pinned because CI targets net10.0 (see
+# .github/workflows/config.yml) and this single SDK can build every framework
+# the connector multi-targets (net462/471/48, netstandard2.0/2.1, net6.0/8.0/9.0/10.0)
+# by restoring reference packs on demand.
+FROM mcr.microsoft.com/dotnet/sdk:10.0
+
+ENV DOTNET_CLI_TELEMETRY_OPTOUT=1 \
+    DOTNET_NOLOGO=1 \
+    DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
+
+# git and curl support source control and tooling; the MySQL/MariaDB client is
+# used by the repository's SingleStore integration-test helper scripts under
+# .github/workflows and .ci.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        curl \
+        git \
+        default-mysql-client \
+    && rm -rf /var/lib/apt/lists/*

--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,8 @@
+{
+  "name": "SingleStore .NET Connector",
+  "user": "root",
+  "build": {
+    "dockerfile": "Dockerfile"
+  },
+  "install": "dotnet restore SingleStoreConnector.slnx && dotnet build -c Release"
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a repository-managed Cloud Agent development environment so the SingleStore .NET Connector can be built and tested in Cursor Cloud Agents out of the box.

- `.cursor/Dockerfile` — pins the **.NET 10 SDK** (`mcr.microsoft.com/dotnet/sdk:10.0`), which CI targets (`net10.0`) and which can build every framework the connector multi-targets (`net462/471/48`, `netstandard2.0/2.1`, `net6.0/8.0/9.0/10.0`). Also installs `git`, `curl`, `ca-certificates`, and the MySQL/MariaDB client used by the repo's integration-test helper scripts.
- `.cursor/environment.json` — uses that Dockerfile and runs `dotnet restore SingleStoreConnector.slnx && dotnet build -c Release` on install to warm the build.

## Design notes

- The .NET SDK is a stable toolchain, so it lives in the Dockerfile; only the source-derived restore/build runs in `install`. The install command is idempotent (a second run is a no-op incremental build).
- Scope is the unblocked core development experience: full multi-framework build, unit tests, and DependencyInjection tests. The database-backed suites (`SideBySide`, `Conformance`, `NativeAot`) require a running SingleStore server, which needs Docker plus a `LICENSE_KEY` secret — that remains a follow-up (documented below) rather than a hard dependency of the environment.

## Validation

All performed in the Cloud Agent VM.

| Check | Result |
| --- | --- |
| `docker build` of `.cursor/Dockerfile` | Image builds successfully |
| Tool versions in image | .NET SDK 10.0.400, git 2.43.0, MySQL client 8.0.46 |
| `install` command inside the image (clean checkout) | Build succeeded, 0 errors |
| Full `dotnet build -c Release` (host) | 0 warnings, 0 errors |
| Unit tests (`SingleStoreConnector.Tests`, net10.0, CI mode) | 706 passed, 0 failed |
| DependencyInjection tests (net10.0) | 15 passed, 0 failed |
| `dotnet format whitespace --verify-no-changes` | Passed |
| Install idempotence | Passed (full build, then no-op rebuild) |
| End-to-end connector flow vs. live server | Connect + CREATE + parameterized INSERT + async SELECT succeeded |

The end-to-end flow was exercised with a small console app built against the connector, run against a live MySQL-protocol server (MariaDB), performing a real create/insert/read cycle.

## Follow-up (optional)

To run the SingleStore integration suites (`SideBySide`, `Conformance`, `NativeAot`) in the environment, a `LICENSE_KEY` secret and a Dockerized SingleStore dev server would need to be wired in. Happy to add this if desired.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-adb2ed5a-5df9-465a-8f4a-847991653310?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-adb2ed5a-5df9-465a-8f4a-847991653310&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

