### PR TITLE
Fix flaky UseReaderWithoutDisposing test on high-latency servers

### DIFF
--- a/tests/SideBySide/QueryTests.cs
+++ b/tests/SideBySide/QueryTests.cs
@@ -721,6 +721,13 @@ insert into query_null_parameter (id, value) VALUES (1, 'one'), (2, 'two'), (3, 
 		var csb = AppConfig.CreateConnectionStringBuilder();
 		csb.MaximumPoolSize = 8;
 
+		// This test intentionally starts more threads than MaximumPoolSize and leaves readers undisposed,
+		// so returning each connection to the pool requires a session reset. Against a high-latency managed
+		// server those resets are slow enough that excess threads can exceed the default 15s pool-wait
+		// timeout and fail with "Connect Timeout expired. All pooled connections are in use." Use a generous
+		// timeout so the test exercises pool reuse without being sensitive to connection latency.
+		csb.ConnectionTimeout = 60;
+
 		using (var connection = new SingleStoreConnection(csb.ConnectionString))
 		{
 			connection.Execute(@"drop table if exists dispose_reader;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

CI run [33603340491](https://github.com/memsql/SingleStoreNETConnector/actions/runs/33603340491) (PR [#24](https://github.com/memsql/SingleStoreNETConnector/pull/24)) failed in `test-windows` → **Run SideBySide tests**:

```
Failed SideBySide.QueryTests.UseReaderWithoutDisposing [44 s]
  SingleStoreConnector.SingleStoreException : Connect Timeout expired. All pooled connections are in use.
```

PR #24 only edits `RELEASE.md`, so this is unrelated to the PR — it's a pre-existing, latency-sensitive flake. It failed only on the **Windows job**, which runs against the remote **S2MS** managed cluster (`aws-oregon`), while every local-cluster Linux job passed.

## Root cause

`UseReaderWithoutDisposing` starts `MaximumPoolSize + 4` (12) threads against a pool of 8 and deliberately leaves each `DbDataReader` undisposed. Disposing a connection whose reader still has unread rows requires a **session reset** (network round-trips) before the connection can be reused. Against a high-latency managed server those resets are slow enough that the 4 excess threads can exceed the **default 15s pool-wait timeout** (`ConnectionTimeout`) and throw `Connect Timeout expired. All pooled connections are in use.` (`SingleStoreConnection.cs`). Loopback-latency local clusters never hit this.

Note the repo already scales timing-sensitive tests via `AppConfig.TimeoutDelayFactor`, but that only recognizes AppVeyor/Travis/TF_Build/CircleCI — **not GitHub Actions** — so timeouts aren't scaled on the GitHub Windows runner. Broadening `IsCiBuild` would have side effects (it also disables `ServerFeatures.Timeout` tests), so this change is scoped to the one affected test.

## Fix

Give the test a generous pool-wait `ConnectionTimeout` (60s) so it still exercises pool reuse under contention without being sensitive to connection latency.

## Verification

Reproduced and verified locally against MariaDB reached through a TCP proxy that injects 50 ms/chunk/direction latency (simulating the remote cluster's RTT). With latency and load held fixed, only `ConnectionTimeout` was varied:

| Scenario | `ConnectionTimeout` | Result |
| --- | --- | --- |
| Reproduction (through latency proxy) | 2s | **FAIL** — `Connect Timeout expired. All pooled connections are in use.` (44s, identical to CI) |
| Fix (through latency proxy) | 60s | **PASS** (1m7s) |
| Sanity (direct DB, no proxy) | 60s | **PASS** (53ms) |

The reproduction produced the exact same exception and duration as the failing CI job, isolating the pool-wait timeout as the cause.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-adb2ed5a-5df9-465a-8f4a-847991653310?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-adb2ed5a-5df9-465a-8f4a-847991653310&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

